### PR TITLE
Allow querying based on bounds parameter

### DIFF
--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -8,7 +8,6 @@ djangorestframework==3.8.2
 djangorestframework-gis==0.13
 Markdown==2.6.11
 django-simple-history==2.3.0
-django-filter==1.1.0
 coverage==4.5.1
 codacy-coverage==1.3.11
 django-colorfield==0.1.15

--- a/project/api/models.py
+++ b/project/api/models.py
@@ -1,13 +1,10 @@
 from json import loads
-from django.conf import settings
+
 from django.core.exceptions import ValidationError
 from django.contrib.gis.db import models
-from django.db.models.signals import post_save
-from django.dispatch import receiver
 from django.contrib.postgres.fields import ArrayField
 from simple_history.models import HistoricalRecords
 from colorfield.fields import ColorField
-from rest_framework.authtoken.models import Token
 
 # Create your models here.
 class Nation(models.Model):
@@ -98,11 +95,3 @@ class DiplomaticRelation(models.Model):
         or something similar?
     """
     pass
-
-@receiver(post_save, sender=settings.AUTH_USER_MODEL)
-def create_auth_token(sender, instance=None, created=False, **kwargs):
-    """
-    Automatically creates a token when a user is registered
-    """
-    if created:
-        Token.objects.create(user=instance)

--- a/project/api/tests.py
+++ b/project/api/tests.py
@@ -141,6 +141,16 @@ class APITest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data[0]["nation"], 1)
 
+    def test_api_can_query_territories_bounds(self):
+        """
+        Ensure querying for bounds in which the nation does not
+        lie in fails
+        """
+        url = reverse("territory-list")+"?bounds=((0.0, 0.0), (0.0, 50.0), (50.0, 50.0), (50.0, 0.0), (0.0, 0.0))"
+        response = self.client.get(url, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(not response.data)
+
     def test_api_can_query_nation(self):
         """
         Ensure we can query individual nations

--- a/project/api/tests.py
+++ b/project/api/tests.py
@@ -143,6 +143,16 @@ class APITest(APITestCase):
 
     def test_api_can_query_territories_bounds(self):
         """
+        Ensure we can query for territories within a bounded
+        region
+        """
+        url = reverse("territory-list")+"?bounds=((0.0, 0.0), (0.0, 150.0), (150.0, 150.0), (150.0, 0.0), (0.0, 0.0))"
+        response = self.client.get(url, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data[0]["nation"], 1)
+
+    def test_api_can_not_query_territories_bounds(self):
+        """
         Ensure querying for bounds in which the nation does not
         lie in fails
         """

--- a/project/api/views.py
+++ b/project/api/views.py
@@ -30,7 +30,7 @@ class TerritoryViewSet(viewsets.ModelViewSet):
         bounds = self.request.query_params.get('bounds', None)
         if bounds is not None:
             geom = Polygon(make_tuple(bounds), srid=4326)
-            self.queryset = Territory.objects.filter(geo__bbcontains=geom)
+            self.queryset = Territory.objects.filter(geo__bboverlaps=geom)
         else:
             return self.queryset
 

--- a/project/api/views.py
+++ b/project/api/views.py
@@ -31,8 +31,7 @@ class TerritoryViewSet(viewsets.ModelViewSet):
         if bounds is not None:
             geom = Polygon(make_tuple(bounds), srid=4326)
             self.queryset = Territory.objects.filter(geo__intersects=geom)
-            return self.queryset
-        else:
-            return self.queryset
+
+        return self.queryset
 
     # TODO use request.user to update revision table

--- a/project/api/views.py
+++ b/project/api/views.py
@@ -30,7 +30,8 @@ class TerritoryViewSet(viewsets.ModelViewSet):
         bounds = self.request.query_params.get('bounds', None)
         if bounds is not None:
             geom = Polygon(make_tuple(bounds), srid=4326)
-            self.queryset = Territory.objects.filter(geo__bboverlaps=geom)
+            self.queryset = Territory.objects.filter(geo__intersects=geom)
+            return self.queryset
         else:
             return self.queryset
 

--- a/project/api/views.py
+++ b/project/api/views.py
@@ -1,7 +1,7 @@
 from ast import literal_eval as make_tuple
 from django.contrib.auth.models import User
 from django.contrib.gis.geos import Polygon
-from rest_framework import viewsets, permissions, generics
+from rest_framework import viewsets, permissions
 
 from .models import Nation, Territory
 from .serializers import NationSerializer, TerritorySerializer, UserSerializer
@@ -30,7 +30,7 @@ class TerritoryViewSet(viewsets.ModelViewSet):
         bounds = self.request.query_params.get('bounds', None)
         if bounds is not None:
             geom = Polygon(make_tuple(bounds), srid=4326)
-            self.queryset = Territory.objects.filter(geo__within=geom)
+            self.queryset = Territory.objects.filter(geo__bbcontains=geom)
         else:
             return self.queryset
 

--- a/project/interactivemap/urls.py
+++ b/project/interactivemap/urls.py
@@ -18,6 +18,5 @@ from django.urls import path, include
 
 urlpatterns = [
     path('api/', include('api.urls')),
-    path('api-auth/', include('rest_framework.urls')),
     path('admin/', admin.site.urls),
 ]


### PR DESCRIPTION
Example request: `http://localhost/api/territories/?bounds=((0.0,%200.0),%20(0.0,%2050.0),%20(50.0,%2050.0),%20(50.0,%200.0),%20(0.0,%200.0))`

Note that it must be parsed as a tuple of tuples (I think a dict with []s might work as well but I don't really care enough to test it), and to enforce a closed polygon it requires that the last tuple is the same as the first.