### PR TITLE
Add date filter

### DIFF
--- a/project/api/serializers.py
+++ b/project/api/serializers.py
@@ -28,19 +28,3 @@ class TerritorySerializer(ModelSerializer):
                   "end_date",
                   "geo",
                   "nation")
-
-class UserSerializer(ModelSerializer):
-    """
-    Serializes the User model, password cannot be read
-    """
-    class Meta:
-        model = User
-        fields = ("username", "email", "password")
-        read_only_fields = ('is_staff', 'is_superuser', 'is_active', 'date_joined',)
-        extra_kwargs = {
-            "password": {"write_only": True}
-        }
-
-    def create(self, validated_data):
-        user = User.objects.create_user(**validated_data)
-        return user

--- a/project/api/tests.py
+++ b/project/api/tests.py
@@ -161,6 +161,26 @@ class APITest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertTrue(not response.data)
 
+    def test_api_can_query_territories_date(self):
+        """
+        Ensure we can query for territories within a bounded
+        region
+        """
+        url = reverse("territory-list")+"?date=2011-01-1"
+        response = self.client.get(url, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data[0]["nation"], 1)
+
+    def test_api_can_not_query_territories_date(self):
+        """
+        Ensure querying for bounds in which the nation does not
+        lie in fails
+        """
+        url = reverse("territory-list")+"?date=2020-01-01"
+        response = self.client.get(url, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(not response.data)
+
     def test_api_can_query_nation(self):
         """
         Ensure we can query individual nations

--- a/project/api/views.py
+++ b/project/api/views.py
@@ -4,7 +4,7 @@ from django.contrib.gis.geos import Polygon
 from rest_framework import viewsets, permissions
 
 from .models import Nation, Territory
-from .serializers import NationSerializer, TerritorySerializer, UserSerializer
+from .serializers import NationSerializer, TerritorySerializer
 
 class NationViewSet(viewsets.ModelViewSet):
     """
@@ -31,6 +31,11 @@ class TerritoryViewSet(viewsets.ModelViewSet):
         if bounds is not None:
             geom = Polygon(make_tuple(bounds), srid=4326)
             self.queryset = Territory.objects.filter(geo__intersects=geom)
+
+        date = self.request.query_params.get('date', None)
+        if date is not None:
+            self.queryset = Territory.objects.filter(start_date__lte=date,
+                                                     end_date__gte=date)
 
         return self.queryset
 


### PR DESCRIPTION
Small and simple PR to allow date filtering to be performed on territories via a query string. Fixes #16.

```
$ curl --request GET \
>   --url http://localhost:8006/api/territories/?date=2018-08-21 \
>   --header 'authorization: Bearer [access token]'
[{"start_date":"2018-08-21","end_date":"2018-08-22","geo":{"type":"Polygon","coordinates":[[[-0.041461995653428,0.044347470419047],[0.077327677198135,0.098592421308485],[0.106510111280166,0.000402162347075],[-0.041461995653428,0.044347470419047]]]},"nation":1}]
```