### PR TITLE
Allow tests to be run with -k

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,5 +39,14 @@ test: ## Builds, starts, and runs containers, running the django tests
 exec_test: ## Builds, starts, and runs containers, running the django tests
 	docker-compose exec web python manage.py test
 
+testk: ## Run Django tests, keeping the database schema from the previous test run
+	docker-compose run web python manage.py test -k
+
+bash: ## SSH into the docker container
+	docker-compose run web /bin/bash
+
+shell: ## Open the django shell
+	docker-compose run web python manage.py shell
+
 admin: ## Creates a super user in the running `web` container based on the values supplied in the configuration file [NOT WORKING ATM]
 	docker-compose exec web ./manage.py shell -c "from django.contrib.auth.models import User; User.objects.create_superuser('$(ADMIN_USER)', '$(ADMIN_EMAIL)', '$(ADMIN_PASS)')"

--- a/Makefile
+++ b/Makefile
@@ -36,11 +36,14 @@ exec_debug: ## Runs built-in Django web server
 test: ## Builds, starts, and runs containers, running the django tests
 	docker-compose run --service-ports web sh init.sh python manage.py test
 
-exec_test: ## Builds, starts, and runs containers, running the django tests
+exec_test: ## Executes django tests in a running container
 	docker-compose exec web python manage.py test
 
 testk: ## Run Django tests, keeping the database schema from the previous test run
 	docker-compose run web python manage.py test -k
+
+exec_testk: ## Executes django tests in a running container
+	docker-compose exec web python manage.py test -k
 
 bash: ## SSH into the docker container
 	docker-compose run web /bin/bash

--- a/project/api/tests.py
+++ b/project/api/tests.py
@@ -250,7 +250,7 @@ class APITest(APITestCase):
         response = self.client.post(url, data, format="json")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(Nation.objects.count(), 3)
-        self.assertEqual(Nation.objects.get(pk=3).name, "Created Test Nation")
+        self.assertEqual(Nation.objects.last().name, "Created Test Nation")
 
     def test_api_can_update_nation(self):
         """
@@ -295,7 +295,7 @@ class APITest(APITestCase):
         data = {
             "start_date": "0008-01-01",
             "end_date": "0009-01-01",
-            "nation": 1,
+            "nation": self.new_nation.id,
             "references": ["https://en.wikipedia.org/wiki/Test"],
             "geo": '{"type": "FeatureCollection","features": [{"type": "Feature","id": "id0","geometry": {"type": "Polygon","coordinates": [[[100,0],[101,0],[101,1],[100,1],[100,0]]]},"properties": {"prop0": "value0","prop1": "value1"}},{"type": "Feature","properties": {},"geometry": {"type": "Polygon","coordinates": [[[101.22802734375,-1.043643455908483],[102.601318359375,-2.2516174965491453],[102.864990234375,-0.36254640877525024],[101.22802734375,-1.043643455908483]]]}}]}',
         }
@@ -303,7 +303,7 @@ class APITest(APITestCase):
         response = self.client.post(url, data, format="json")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(Territory.objects.count(), 3)
-        self.assertEqual(Territory.objects.last().nation, Nation.objects.get(pk=1))
+        self.assertEqual(Territory.objects.last().nation, self.new_nation)
 
     def test_api_can_create_territory(self):
         """
@@ -313,7 +313,7 @@ class APITest(APITestCase):
         data = {
             "start_date": "0006-01-01",
             "end_date": "0007-01-01",
-            "nation": 1,
+            "nation": self.new_nation.id,
             "references": ["https://en.wikipedia.org/wiki/Test"],
             "geo": '{"type": "MultiPolygon","coordinates": [[[ [102.0, 2.0], [103.0, 2.0], [103.0, 3.0], [102.0, 3.0], [102.0, 2.0] ]],[[ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ],[ [100.2, 0.2], [100.8, 0.2], [100.8, 0.8], [100.2, 0.8], [100.2, 0.2] ]]]}',
         }
@@ -321,23 +321,23 @@ class APITest(APITestCase):
         response = self.client.post(url, data, format="json")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(Territory.objects.count(), 3)
-        self.assertEqual(Territory.objects.last().nation, Nation.objects.get(pk=1))
+        self.assertEqual(Territory.objects.last().nation, self.new_nation)
 
     def test_api_can_update_territory(self):
         """
         Ensure we can update individual territories
         """
-        url = reverse("territory-detail", args=[1])
+        url = reverse("territory-detail", args=[self.territory.id])
         data = {
             "start_date": "0010-01-01",
             "end_date": "0011-01-01",
-            "nation": 1,
+            "nation": self.child_nation.id,
             "geo": '{"type": "MultiPolygon","coordinates": [[[ [102.0, 2.0], [103.0, 2.0], [103.0, 3.0], [102.0, 3.0], [102.0, 2.0] ]],[[ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ],[ [100.2, 0.2], [100.8, 0.2], [100.8, 0.8], [100.2, 0.8], [100.2, 0.2] ]]]}',
         }
         self.client.credentials(HTTP_AUTHORIZATION="Bearer " + getUserToken())
         response = self.client.put(url, data, format="json")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data["nation"], "test_nation")
+        self.assertEqual(response.data["nation"], self.child_nation.url_id)
 
     def test_api_can_query_territories(self):
         """
@@ -352,7 +352,7 @@ class APITest(APITestCase):
         """
         Ensure we can query individual territories
         """
-        url = reverse("territory-detail", args=[1])
+        url = reverse("territory-detail", args=[self.territory.id])
         response = self.client.get(url, format="json")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["nation"], "test_nation")
@@ -422,27 +422,27 @@ class APITest(APITestCase):
             "start_date": "0001-01-01",
             "end_date": "0005-01-01",
             "references": ["https://en.wikipedia.org/wiki/Test"],
-            "parent_parties": [1],
-            "child_parties": [1],
+            "parent_parties": [self.new_nation.id],
+            "child_parties": [self.child_nation.id],
             "diplo_type": "A",
         }
         self.client.credentials(HTTP_AUTHORIZATION="Bearer " + getUserToken())
         response = self.client.post(url, data, format="json")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(DiplomaticRelation.objects.count(), 2)
-        self.assertEqual(DiplomaticRelation.objects.get(pk=2).diplo_type, "A")
+        self.assertEqual(DiplomaticRelation.objects.last().diplo_type, "A")
 
     def test_api_can_update_diprel(self):
         """
         Ensure we can update individual DipRels
         """
-        url = reverse("diplomaticrelation-detail", args=[1])
+        url = reverse("diplomaticrelation-detail", args=[self.diprel.id])
         data = {
             "start_date": "0006-01-01",
             "end_date": "0010-01-01",
             "references": ["https://en.wikipedia.org/wiki/Test"],
-            "parent_parties": [1],
-            "child_parties": [1],
+            "parent_parties": [self.new_nation.id],
+            "child_parties": [self.new_nation.id],
             "diplo_type": "A",
         }
         self.client.credentials(HTTP_AUTHORIZATION="Bearer " + getUserToken())
@@ -463,7 +463,7 @@ class APITest(APITestCase):
         """
         Ensure we can query individual DipRels
         """
-        url = reverse("diplomaticrelation-detail", args=[1])
+        url = reverse("diplomaticrelation-detail", args=[self.diprel.id])
         response = self.client.get(url, format="json")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["diplo_type"], "A")


### PR DESCRIPTION
Context: https://docs.djangoproject.com/en/2.1/topics/testing/overview/#preserving-the-test-database

Running tests like `./manage.py test -k` reduces the runtime of tests. This will become more dramatic as our schema becomes more complex and our test suite grows.