### PR TITLE
Add sign up form

### DIFF
--- a/project/api/templates/signup.html
+++ b/project/api/templates/signup.html
@@ -1,0 +1,8 @@
+{% block content %}
+<h2>Sign up</h2>
+<form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit">Sign up</button>
+</form>
+{% endblock %}

--- a/project/api/urls.py
+++ b/project/api/urls.py
@@ -8,4 +8,4 @@ ROUTER.register(r"politicalentities", views.PoliticalEntityViewSet)
 ROUTER.register(r"territories", views.TerritoryViewSet)
 ROUTER.register(r"diprels", views.DiplomaticRelationViewSet)
 
-urlpatterns = [path("", include(ROUTER.urls))]
+urlpatterns = [path("", include(ROUTER.urls)), path("signup/", views.signup)]

--- a/project/api/views.py
+++ b/project/api/views.py
@@ -61,7 +61,7 @@ def signup(request):
             new_user.is_staff = True
             new_user.save()
             try:
-                new_user.groups.add(Group.objects.get(name='mapper'))
+                new_user.groups.add(Group.objects.get(name="mapper"))
             except Group.DoesNotExist:
                 pass
 


### PR DESCRIPTION
Adds a very basic user creation form to the admin interface. Users created by default do not have permission to do anything, but a `mappers` group can be created to extend this. Fixes #62. 