### PR TITLE
Admin page metadata

### DIFF
--- a/project/api/admin.py
+++ b/project/api/admin.py
@@ -6,3 +6,7 @@ from .models import *
 admin.site.register(Territory, SimpleHistoryAdmin)
 admin.site.register(PoliticalEntity, SimpleHistoryAdmin)
 admin.site.register(DiplomaticRelation, SimpleHistoryAdmin)
+
+admin.site.site_header = "ChronoScio Database"
+admin.site.site_title = "ChronoScio editor"
+admin.site.index_title = "Edit data"


### PR DESCRIPTION
Small PR to update admin page metadata from the default to reflect our project information. After this, #63, 
and #61 are merged, admin page should be available for use by the mappers :+1: