### PR TITLE
Fix ValidationError upon editing territory

### DIFF
--- a/project/api/models.py
+++ b/project/api/models.py
@@ -115,11 +115,15 @@ class Territory(models.Model):
 
         try:
             # This date check is inculsive.
-            if Territory.objects.filter(
-                start_date__lte=self.end_date,
-                end_date__gte=self.start_date,
-                entity__exact=self.entity,
-            ).exists():
+            if (
+                Territory.objects.filter(
+                    start_date__lte=self.end_date,
+                    end_date__gte=self.start_date,
+                    entity__exact=self.entity,
+                )
+                .exclude(pk__exact=self.pk)
+                .exists()
+            ):
                 raise ValidationError(
                     "Another territory of this PoliticalEntity exists during this timeframe."
                 )


### PR DESCRIPTION
Just noticed this today, when editing a territory the changed if block would fail due to the fact that the filter check would pass if the parent nation and start and end dates remained the same. In other words, changing only the `geo` or `references` field would raise a ValidationError.