### PR TITLE
Auto-generated model documentation

### DIFF
--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -23,3 +23,4 @@ pyjwt==1.6.4
 pylint-django==0.11.1
 pylint==1.8.4
 geobuf==1.1.1
+docutils==0.14

--- a/project/interactivemap/settings.py
+++ b/project/interactivemap/settings.py
@@ -104,7 +104,7 @@ DATABASES = {
         "NAME": "postgres",
         "USER": "postgres",
         "PASSWORD": "postgres",
-        "HOST": "localhost",
+        "HOST": "db",
         "PORT": 5432,
     }
 }

--- a/project/interactivemap/settings.py
+++ b/project/interactivemap/settings.py
@@ -38,6 +38,7 @@ ALLOWED_HOSTS = ["*"]
 
 INSTALLED_APPS = [
     "django.contrib.admin",
+    "django.contrib.admindocs",
     "django.contrib.auth",
     "django.contrib.contenttypes",
     "django.contrib.sessions",
@@ -103,7 +104,7 @@ DATABASES = {
         "NAME": "postgres",
         "USER": "postgres",
         "PASSWORD": "postgres",
-        "HOST": "db",
+        "HOST": "localhost",
         "PORT": 5432,
     }
 }

--- a/project/interactivemap/urls.py
+++ b/project/interactivemap/urls.py
@@ -16,4 +16,4 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path, include
 
-urlpatterns = [path("api/", include("api.urls")), path("admin/", admin.site.urls)]
+urlpatterns = [path('admin/doc/', include('django.contrib.admindocs.urls')), path("api/", include("api.urls")), path("admin/", admin.site.urls)]

--- a/project/interactivemap/urls.py
+++ b/project/interactivemap/urls.py
@@ -16,4 +16,8 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path, include
 
-urlpatterns = [path('admin/doc/', include('django.contrib.admindocs.urls')), path("api/", include("api.urls")), path("admin/", admin.site.urls)]
+urlpatterns = [
+    path("admin/doc/", include("django.contrib.admindocs.urls")),
+    path("api/", include("api.urls")),
+    path("admin/", admin.site.urls),
+]


### PR DESCRIPTION
At the request of @Delh, this PR provides auto generated documentation (based off of docstrings and `help_text` for our database Models at the `/admin/api/` endpoint. 